### PR TITLE
Define non-detectable blocks in config.yml

### DIFF
--- a/src/main/kotlin/MinecraftStarshipPlugin.kt
+++ b/src/main/kotlin/MinecraftStarshipPlugin.kt
@@ -16,6 +16,7 @@ class MinecraftStarshipPlugin: JavaPlugin() {
 
 	override fun onEnable() {
 		plugin = this
+		plugin.saveDefaultConfig() // Save the default config, doesn't overwrite existing
 
 		Bukkit.getPluginManager().registerEvents(Interface(), this)
 	}

--- a/src/main/kotlin/MinecraftStarshipPlugin.kt
+++ b/src/main/kotlin/MinecraftStarshipPlugin.kt
@@ -2,6 +2,7 @@ package io.github.petercrawley.minecraftstarshipplugin
 
 import io.github.petercrawley.minecraftstarshipplugin.ships.Interface
 import org.bukkit.Bukkit
+import org.bukkit.Material
 import org.bukkit.plugin.java.JavaPlugin
 
 class MinecraftStarshipPlugin: JavaPlugin() {
@@ -14,10 +15,23 @@ class MinecraftStarshipPlugin: JavaPlugin() {
 		}
 	}
 
+	val nonDetectableBlocks: MutableSet<Material> = mutableSetOf(Material.AIR)
+
 	override fun onEnable() {
 		plugin = this
 		plugin.saveDefaultConfig() // Save the default config, doesn't overwrite existing
 
 		Bukkit.getPluginManager().registerEvents(Interface(), this)
+
+		// Get the non-detectable blocks from the config file
+		// TODO: Config reload command
+		config.getStringList("non-detectable-blocks").forEach {
+			if (Material.getMaterial(it) == null){
+				logger.warning("No Material for $it! Make sure all non-detectable blocks are correctly named!")
+			}
+			else {
+				nonDetectableBlocks.add(Material.getMaterial(it)!!)
+			}
+		}
 	}
 }

--- a/src/main/kotlin/ships/Starship.kt
+++ b/src/main/kotlin/ships/Starship.kt
@@ -19,20 +19,6 @@ class Starship(private val origin: MSPLocation, private val owner: Player) {
 		Bukkit.getScheduler().runTaskAsynchronously(MinecraftStarshipPlugin.getPlugin(), Runnable {
 			owner.sendMessage("Detecting Starship.")
 
-			// Get the non-detectable blocks from the config file
-			// Probably not necessary to have this here, could probably be done on a config reload
-			val nonDetectableBlocks: MutableSet<Material> = mutableSetOf(Material.AIR)
-
-			MinecraftStarshipPlugin.getPlugin().config.getStringList("non-detectable-blocks").forEach {
-				if (Material.getMaterial(it) == null){
-					MinecraftStarshipPlugin.getPlugin().logger.
-					warning("No Material for $it! Make sure all non-detectable blocks are correctly named!")
-				}
-				else {
-					nonDetectableBlocks.add(Material.getMaterial(it)!!)
-				}
-			}
-
 			val checkedBlocks: MutableSet<MSPLocation> = mutableSetOf()
 			val blocksToCheck: MutableSet<MSPLocation> = mutableSetOf()
 
@@ -51,7 +37,7 @@ class Starship(private val origin: MSPLocation, private val owner: Player) {
 
 				checkedBlocks.add(currentBlock)
 
-				if (nonDetectableBlocks.contains(currentBlock.bukkit().block.type)) continue
+				if (MinecraftStarshipPlugin.getPlugin().nonDetectableBlocks.contains(currentBlock.bukkit().block.type)) continue
 
 				detectedBlocks.add(currentBlock)
 

--- a/src/main/kotlin/ships/Starship.kt
+++ b/src/main/kotlin/ships/Starship.kt
@@ -19,10 +19,19 @@ class Starship(private val origin: MSPLocation, private val owner: Player) {
 		Bukkit.getScheduler().runTaskAsynchronously(MinecraftStarshipPlugin.getPlugin(), Runnable {
 			owner.sendMessage("Detecting Starship.")
 
-			// TODO: This should be loaded from a config file.
-			val nonDetectableBlocks: Set<Material> = setOf(
-				Material.AIR
-			)
+			// Get the non-detectable blocks from the config file
+			// Probably not the best idea to put it here, this should probably be done on a config reload
+			val nonDetectableBlocks: MutableSet<Material> = mutableSetOf(Material.AIR)
+
+			MinecraftStarshipPlugin.getPlugin().config.getStringList("non-detectable-blocks").forEach {
+				if (Material.getMaterial(it) == null){
+					MinecraftStarshipPlugin.getPlugin().logger.
+					warning("No Material for $it! Make sure all non-detectable blocks are correctly named!")
+				}
+				else {
+					nonDetectableBlocks.add(Material.getMaterial(it)!!)
+				}
+			}
 
 			val checkedBlocks: MutableSet<MSPLocation> = mutableSetOf()
 			val blocksToCheck: MutableSet<MSPLocation> = mutableSetOf()

--- a/src/main/kotlin/ships/Starship.kt
+++ b/src/main/kotlin/ships/Starship.kt
@@ -20,7 +20,7 @@ class Starship(private val origin: MSPLocation, private val owner: Player) {
 			owner.sendMessage("Detecting Starship.")
 
 			// Get the non-detectable blocks from the config file
-			// Probably not the best idea to put it here, this should probably be done on a config reload
+			// Probably not necessary to have this here, could probably be done on a config reload
 			val nonDetectableBlocks: MutableSet<Material> = mutableSetOf(Material.AIR)
 
 			MinecraftStarshipPlugin.getPlugin().config.getStringList("non-detectable-blocks").forEach {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,2 @@
+non-detectable-blocks:
+  - DIRT


### PR DESCRIPTION
Right now it uses the default `config.yml` file. It can be changed to some other file if you don't want the main config getting too messy, see https://www.spigotmc.org/wiki/config-files/.

Honestly this probably doesn't need to be done every time someone tries to detect a ship, but whatever.