### PR TITLE
Update plugin.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 main: io.github.petercrawley.minecraftstarshipplugin.MinecraftStarshipPlugin
 name: Minecraft-Starship-Plugin
 version: 1.0.0
-description: A shameless rip-off of Star Legacy's plguins.
+description: An open-source plugin that accommodates starships on minecraft servers.  `A shameless rip-off of Star Legacy`s plguins.`
 api-version: 1.17
 load: STARTUP
 author: Peter-Crawley


### PR DESCRIPTION
'A shameless rip-off of Star Legacy's plugins.' should not be an advertising slogan.  Also replaced an apostrophe with a backtick because of a formatting issue which already existed.